### PR TITLE
Backfill missing `-rc` versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,15 @@
 <li>MinGit (BusyBox): <a href="https://github.com/git-for-windows/git-snapshots/releases/download/prerelease-2.49.0-rc1.windows.1-2-g511a07b339-20250310140624/MinGit-prerelease-2.49.0-rc1.windows.1-2-g511a07b339-20250310140624-busybox-64-bit.zip">x64 (64-bit)</a> and <a href="https://github.com/git-for-windows/git-snapshots/releases/download/prerelease-2.49.0-rc1.windows.1-2-g511a07b339-20250310140624/MinGit-prerelease-2.49.0-rc1.windows.1-2-g511a07b339-20250310140624-busybox-32-bit.zip">x86 (32-bit)</a>.</li>
 </ul>
 
+<h2 id="2025-03-05T12:01:38.000Z"><a class="anchor" href="#2025-03-05T12:01:38.000Z">&#128279;</a>Wed, Mar 5, 2025, 12:01:38 GMT<br />(commit <a href="https://github.com/git-for-windows/git/commit/31963038164d1a2d78dc46225f8441e8c0fb07a8">31963038164d1a2d78dc46225f8441e8c0fb07a8</a>)</h2>
+
+<ul>
+<li>Git for Windows installer: <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc1.windows.1/Git-2.49.0-rc1-64-bit.exe">x64 (64-bit)</a> and <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc1.windows.1/Git-2.49.0-rc1-arm64.exe">ARM64</a>.</li>
+<li>Portable Git (self-extracting <tt>.7z</tt> archive): <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc1.windows.1/PortableGit-2.49.0-rc1-64-bit.7z.exe">x64 (64-bit)</a> and <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc1.windows.1/PortableGit-2.49.0-rc1-arm64.7z.exe">ARM64</a>.</li>
+<li>MinGit: <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc1.windows.1/MinGit-2.49.0-rc1-64-bit.zip">x64 (64-bit)</a>, <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc1.windows.1/MinGit-2.49.0-rc1-arm64.zip">ARM64</a> and <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc1.windows.1/MinGit-2.49.0-rc1-32-bit.zip">x86 (32-bit)</a>.</li>
+<li>MinGit (BusyBox): <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc1.windows.1/MinGit-2.49.0-rc1-busybox-64-bit.zip">x64 (64-bit)</a> and <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc1.windows.1/MinGit-2.49.0-rc1-busybox-32-bit.zip">x86 (32-bit)</a>.</li>
+</ul>
+
 <h2 id="2025-03-04T18:54:35.000Z"><a class="anchor" href="#2025-03-04T18:54:35.000Z">&#128279;</a>Tue, Mar 4, 2025, 06:54:35 PM GMT<br />(commit <a href="https://github.com/git-for-windows/git/commit/1424e2777e22d3195d9c9926ec3d1909bc0dc1e1">1424e2777e22d3195d9c9926ec3d1909bc0dc1e1</a>)</h2>
 
 <ul>
@@ -53,6 +62,15 @@
 <li>Portable Git (self-extracting <tt>.7z</tt> archive): <a href="https://github.com/git-for-windows/git-snapshots/releases/download/prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532/PortableGit-prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532-64-bit.7z.exe">x64 (64-bit)</a> and <a href="https://github.com/git-for-windows/git-snapshots/releases/download/prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532/PortableGit-prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532-arm64.7z.exe">ARM64</a>.</li>
 <li>MinGit: <a href="https://github.com/git-for-windows/git-snapshots/releases/download/prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532/MinGit-prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532-64-bit.zip">x64 (64-bit)</a>, <a href="https://github.com/git-for-windows/git-snapshots/releases/download/prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532/MinGit-prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532-arm64.zip">ARM64</a> and <a href="https://github.com/git-for-windows/git-snapshots/releases/download/prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532/MinGit-prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532-32-bit.zip">x86 (32-bit)</a>.</li>
 <li>MinGit (BusyBox): <a href="https://github.com/git-for-windows/git-snapshots/releases/download/prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532/MinGit-prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532-busybox-64-bit.zip">x64 (64-bit)</a> and <a href="https://github.com/git-for-windows/git-snapshots/releases/download/prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532/MinGit-prerelease-2.49.0-rc0.windows.1-2-g1424e2777e-20250304185532-busybox-32-bit.zip">x86 (32-bit)</a>.</li>
+</ul>
+
+<h2 id="2025-02-26T20:19:31.000Z"><a class="anchor" href="#2025-02-26T20:19:31.000Z">&#128279;</a>Wed, Feb 26, 2025, 20:19:31 GMT<br />(commit <a href="https://github.com/git-for-windows/git/commit/d20d8cdf84017e3fcf0081f4c2f9ef49647afb08">d20d8cdf84017e3fcf0081f4c2f9ef49647afb08</a>)</h2>
+
+<ul>
+<li>Git for Windows installer: <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc0.windows.1/Git-2.49.0-rc0-64-bit.exe">x64 (64-bit)</a> and <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc0.windows.1/Git-2.49.0-rc0-arm64.exe">ARM64</a>.</li>
+<li>Portable Git (self-extracting <tt>.7z</tt> archive): <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc0.windows.1/PortableGit-2.49.0-rc0-64-bit.7z.exe">x64 (64-bit)</a> and <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc0.windows.1/PortableGit-2.49.0-rc0-arm64.7z.exe">ARM64</a>.</li>
+<li>MinGit: <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc0.windows.1/MinGit-2.49.0-rc0-64-bit.zip">x64 (64-bit)</a>, <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc0.windows.1/MinGit-2.49.0-rc0-arm64.zip">ARM64</a> and <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc0.windows.1/MinGit-2.49.0-rc0-32-bit.zip">x86 (32-bit)</a>.</li>
+<li>MinGit (BusyBox): <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc0.windows.1/MinGit-2.49.0-rc0-busybox-64-bit.zip">x64 (64-bit)</a> and <a href="https://github.com/git-for-windows/git/releases/download/v2.49.0-rc0.windows.1/MinGit-2.49.0-rc0-busybox-32-bit.zip">x86 (32-bit)</a>.</li>
 </ul>
 
 <h2 id="2025-02-26T18:35:33.000Z"><a class="anchor" href="#2025-02-26T18:35:33.000Z">&#128279;</a>Wed, Feb 26, 2025, 06:35:33 PM GMT<br />(commit <a href="https://github.com/git-for-windows/git/commit/ba6e4aaec47e8695bd59117967d9b18b1e477686">ba6e4aaec47e8695bd59117967d9b18b1e477686</a>)</h2>


### PR DESCRIPTION
This addresses part of https://github.com/git-for-windows/git/issues/5482 by back-filling the v2.49.0-rc0 and v2.49.0-rc1 versions.

The underlying problem that prevented these versions from being added to https://gitforwindows.org/git-snapshots (backed by the `gh-pages` branch of this here repository) is being fixed in https://github.com/git-for-windows/gfw-helper-github-app/pull/128.