### PR TITLE
index.html: replace outdated FAQ link

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <div class="links">
 <ul>
 <li><a href="https://gitforwindows.org/">homepage</a></li>
-<li><a href="https://github.com/git-for-windows/git/wiki/FAQ">faq</a></li>
+<li><a href="https://gitforwindows.org/faq">faq</a></li>
 <li><a href="https://gitforwindows.org/#contribute">contribute</a></li>
 <li><a href="https://gitforwindows.org/#contribute">bugs</a></li>
 <li><a href="mailto:git@vger.kernel.org">questions</a></li>


### PR DESCRIPTION
Yet another follow-up for https://github.com/git-for-windows/git-for-windows.github.io/pull/59.